### PR TITLE
Let matchOutput function responsibility to call done fn

### DIFF
--- a/tasks/container.js
+++ b/tasks/container.js
@@ -86,7 +86,7 @@ module.exports = function(grunt) {
               });
 
               stream.on('end', function() {
-                done();
+                options.matchOutput(null);
               });
             });
           } else {


### PR DESCRIPTION
This fixes issue caused by #3: When `done` is called twice, it starts to stop next grunt task.

Use case:

``` JavaScript

//...
matchOutput: regex ? _taskSuccessIfMatch(grunt, regex, info) : _taskSuccessIfStreamEnd(grunt),
//...

function _taskSuccessIfStreamEnd(grunt, verbose) {
  return function(chunk) {
    if (chunk === null) {
      grunt.task.current.async()();
    } else if (verbose) {
      grunt.log.writeln(chunk);
    }
  };
}
```
